### PR TITLE
Stop adjustSubtitle() from moving the subtitles when user_opts.raisesubswithosc is false

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -2667,7 +2667,7 @@ function adjustSubtitles(visible)
         if h > 0 then
             mp.commandv('set', 'sub-pos', math.floor((osc_param.playresy - 175)/osc_param.playresy*100)) -- percentage
         end
-	else
+	elseif user_opts.raisesubswithosc then
 		mp.commandv('set', 'sub-pos', 100)
 	end	
 end


### PR DESCRIPTION
I prefer subtitles on top; but when I noticed that the option `raisesubswithosc` would interfere with that, I disabled it.

Except, there was a tiny bug still giving me trouble.