### PR TITLE
Fix custom title property and hardcoded download path

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -1309,7 +1309,7 @@ end
 
 function downloadDone(success, result, error)
     if success then
-        show_message("\\N{\\an9}Download saved to " .. mp.command_native({"expand-path", "~~desktop/mpv/downloads"}))
+        show_message("\\N{\\an9}Download saved to " .. mp.command_native({"expand-path", user_opts.downloadpath}))
         state.downloadedOnce = true
     else
         show_message("\\N{\\an9}WEB: Download failed - " .. (error or "Unknown error"))

--- a/modernx.lua
+++ b/modernx.lua
@@ -1131,8 +1131,6 @@ function checktitle()
         else
             user_opts.title = "${filename}" -- audio with the same title (without file extension) and filename
         end
-    else
-        user_opts.title = "${media-title}"
     end
 
     -- fake description using metadata


### PR DESCRIPTION
This pull request fixes two issues.
- Custom title property not taking effect.
The 'title' property is already defined and initialised in user_opts. However, the custom title property does not take effect because it was always re-initialised to be '${media-title}'. The offending lines have been removed.
- On downloading a file, the hardcoded download location being shown on screen instead of correct one.