### PR TITLE
Additional tooltip formatting not included in previous PR

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -3060,7 +3060,12 @@ function osc_init()
         local duration = mp.get_property_number('duration', nil)
         if not ((duration == nil) or (pos == nil)) then
             possec = duration * (pos / 100)
-            return mp.format_time(possec)
+            local time = mp.format_time(possec)
+            -- If video is less than 1 hour, strip the "00:" prefix
+            if possec < 3600 then
+                time = time:gsub("^00:", "")
+            end
+            return time
         else
             return ''
         end


### PR DESCRIPTION
Sorry, I forgot to add the commit that formats the tooltip time code in the seekbar to previous PR #59.

### Changes:
- MM:SS only when seeking positions under 1 hour (e.g., 05:30)
- HH:MM:SS when seeking past 1-hour positions (e.g., 01:23:45)