### PR TITLE
Fix crash when switching through video files too fast

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -2556,7 +2556,11 @@ function osc_init()
             title = string.gsub(title, '\\N', ' ')
             return not (title == "") and title or "error"
         else
-            return string.gsub(state.localDescription, '\\N', ' ')
+            if(state.localDescription == nil) then
+                return ""
+            else
+                return string.gsub(state.localDescription, '\\N', ' ')
+            end
         end
     end
     ne.eventresponder['mbtn_left_up'] =


### PR DESCRIPTION
Due to description not being available yet the UI will crash when spam clicking the forwards/back button in the UI.

The problematic call with the first argument occasionally being null is: `return string.gsub(state.localDescription, '\\N', ' ')`