### PR TITLE
fix(modernx): avoid nil error when generating comment filename

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -2,7 +2,7 @@
     ModernX by zydezu
     (https://github.com/zydezu/ModernX)
 
-    This script is a result of the original mpv-osc-modern by maoiscat 
+    This script is a result of the original mpv-osc-modern by maoiscat
     and it's subsequent forks:
     * cyl0/ModernX
     * dexeonify/ModernX
@@ -153,7 +153,7 @@ local user_opts = {
     info_button = false,                    -- show info button
     ontop_button = true,                    -- show window on top button
     screenshot_button = false,              -- show screenshot button
-    screenshot_flag = "subtitles",          -- flag for screenshot button: "subtitles", "video", "window", "each-frame" 
+    screenshot_flag = "subtitles",          -- flag for screenshot button: "subtitles", "video", "window", "each-frame"
                                             -- https://mpv.io/manual/master/#command-interface-screenshot-%3Cflags%3E
 
     download_button = true,                 -- show download button on web videos (requires yt-dlp and ffmpeg)
@@ -226,9 +226,9 @@ local user_opts = {
     add_sponsorblock_chapters = false,      -- add sponsorblock chapters to the chapter list
     sponsorblock_seek_range_alpha = 75,     -- transparency of sponsorblock segments
     sponsor_types = {                       -- what categories to show in the progress bar
-        "sponsor",                          -- all categories: 
-        "intro",                            --      sponsor, intro, outro, 
-        "outro",                            --      interaction, selfpromo, preview, 
+        "sponsor",                          -- all categories:
+        "intro",                            --      sponsor, intro, outro,
+        "outro",                            --      interaction, selfpromo, preview,
         "interaction",                      --      music_offtopic, filler
         "selfpromo",
         "preview",
@@ -293,7 +293,7 @@ local icons = {
         [5] = {"\238\171\186", "\238\171\187"},
         [10] = {"\238\171\188", "\238\172\129"},
         [30] = {"\238\172\133", "\238\172\134"},
-        default = {"\238\172\138", "\238\172\138"}, -- second icon is mirrored in layout() 
+        default = {"\238\172\138", "\238\172\138"}, -- second icon is mirrored in layout()
     },
 
     emoticon = {
@@ -407,7 +407,7 @@ local playpause_size = user_opts.playpause_size or 30
 local midbuttons_size = user_opts.midbuttons_size or 24
 local sidebuttons_size = user_opts.sidebuttons_size or 24
 local osc_styles = {
-    osc_fade_bg = "{\\blur" .. user_opts.fade_blur_strength .. "\\bord" .. user_opts.fade_alpha .. "\\1c&H0&\\3c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",    
+    osc_fade_bg = "{\\blur" .. user_opts.fade_blur_strength .. "\\bord" .. user_opts.fade_alpha .. "\\1c&H0&\\3c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
     window_fade_bg = "{\\blur" .. user_opts.window_fade_blur_strength .. "\\bord" .. user_opts.window_fade_alpha .. "\\1c&H0&\\3c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
     chapter_title = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.chapter_title_color) .. "&\\3c&H000000&\\fs" .. user_opts.time_font_size .. "\\fn" .. user_opts.font .. "}",
     control_1 = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.playpause_color) .. "&\\3c&HFFFFFF&\\fs" .. playpause_size .. "\\fn" .. iconfont .. "}",
@@ -1036,7 +1036,7 @@ local function draw_seekbar_progress(element, elem_ass)
     elem_ass:rect_cw(0, slider_lo.gap, xp, elem_geo.h - slider_lo.gap)
 end
 
--- Draws seekbar ranges according to user_opts 
+-- Draws seekbar ranges according to user_opts
 local function draw_seekbar_ranges(element, elem_ass, xp, rh, override_alpha)
     local handle = xp and rh
     xp = xp or 0
@@ -1506,7 +1506,7 @@ function checktitle()
 
     local metadata = mp.get_property_native('metadata')
     print(dumptable(metadata))
-    
+
     if metadata then
         state.ytdescription = metadata.ytdl_description or description or ""
         state.ytdescription = state.ytdescription:gsub('\r', '\\N'):gsub('\n', '\\N'):gsub("%%", "%%")
@@ -1746,9 +1746,19 @@ function check_comments()
         end
 
         local filename = ""
-        if (mp.get_property("filename")) then
+        local file_prop = mp.get_property("filename")
+        local comments_path = user_opts.comments_download_path or ""
+
+        if file_prop then
             mp.msg.info("[WEB] Downloaded comments")
-            filename = mp.command_native({"expand-path", user_opts.comments_download_path .. '/'}) .. mp.get_property("filename"):gsub("watch%?v=", ""):match("^[^%?&]+") .. ".info.json"
+
+            -- 清洗文件名
+            local clean_name = file_prop:gsub("watch%?v=", "")
+            clean_name = clean_name:match("^[^%?&]+") or clean_name  -- 避免 match 返回 nil
+
+            -- 构建完整路径
+            local base_path = mp.command_native({"expand-path", comments_path .. '/'}) or ""
+            filename = base_path .. clean_name .. ".info.json"
         else
             mp.msg.info("[WEB] Comments failed to download...")
             return
@@ -1961,7 +1971,7 @@ function process_vid_stats(success, result, error)
     if not state.ytdescription then
         if mp.get_property_number("estimated-vf-fps") then
             state.videoDescription = mp.get_property("width") .. "x" .. mp.get_property("height") .. " | FPS: " ..
-            (math.floor(mp.get_property_number("estimated-vf-fps") + 0.5) or "") -- can't get a normal description, display something else    
+            (math.floor(mp.get_property_number("estimated-vf-fps") + 0.5) or "") -- can't get a normal description, display something else
         end
     end
 
@@ -2085,9 +2095,9 @@ local function make_sponsorblock_segments()
 
     if duration then
         for _, chapter in ipairs(temp_chapters) do
-            
+
             print(chapter.title)
-            
+
             if chapter.title then
 
 
@@ -3292,7 +3302,7 @@ local function osc_init()
             if compact_mode then
                 mp.commandv("add", "chapter", 1)
                 show_message(get_chapterlist())
-                show_message(get_chapterlist()) -- run twice as it might show the wrong chapter without another function    
+                show_message(get_chapterlist()) -- run twice as it might show the wrong chapter without another function
             else
                 show_message(get_chapterlist())
             end


### PR DESCRIPTION
### Problem

When playing videos from URLs such as Bilibili, the script `modernx.lua` attempts to construct a `.info.json` path using the video filename. However, if `mp.get_property("filename")` returns `nil`, or if the result of `:match(...)` returns `nil`, the script crashes with the following error:

![图片](https://github.com/user-attachments/assets/42f247a3-8b77-4be9-ae45-f21da06b724e)

This happens at line 1751 and interrupts the playback experience, especially when comments are enabled.

---