### PR TITLE
Fix OSC autohide when `bottom_hover` is disabled

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -4612,7 +4612,7 @@ local function render()
     if not (state.showtime == nil) and (get_hide_timeout() >= 0) then
         local timeout = state.showtime + (get_hide_timeout() / 1000) - now
         if timeout <= 0 then
-            if (state.active_element == nil) and (user_opts.bottom_hover) and (not mouse_over_osc) then
+            if (state.active_element == nil) and (user_opts.bottom_hover) or (not mouse_over_osc) then
                 if (not (state.paused and user_opts.keep_on_pause)) then
                     hide_osc()
                 end


### PR DESCRIPTION
## Description

Fixes an issue where the OSC does not automatically hide when `bottom_hover=no`.

I encountered this after upgrading from v0.4.3 to v0.4.7. After testing the intermediate releases, I found that the regression first appears in v0.4.6.

The current autohide condition requires both `bottom_hover` to be enabled and the mouse to not be over the OSC:

```lua
(user_opts.bottom_hover) and (not mouse_over_osc)
```

As a result, when `bottom_hover` is disabled, the condition can never be true and `hide_osc()` is never called after the hide timeout.

Changing this to:

```lua
(user_opts.bottom_hover) or (not mouse_over_osc)
```

allows the OSC to hide normally when `bottom_hover` is disabled, while retaining the existing cursor-hover behavior.

### Testing

* Confirmed the issue is present in v0.4.6 and v0.4.7.
* Confirmed v0.4.3 does not exhibit the issue.
* Confirmed changing the condition restores OSC autohide behavior.
